### PR TITLE
[CLOUDTRUST-5859] Bump Go to 1.24.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudtrust/httpclient
 
-go 1.22
+go 1.24.1
 
 require (
 	github.com/golang-jwt/jwt/v5 v5.2.2


### PR DESCRIPTION
Ignore XRay scan fail on Jenkins
JFrog CLI uses Go 1.23 (https://github.com/jfrog/jfrog-cli/blob/v2/go.mod#L3)